### PR TITLE
Fixes issue with improper file.src

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,13 @@ module.exports = function (opts) {
 
 		debug('compiling %s to css', file.id);
 
-		file.src = sass(assign({
+		var result = sass(assign({
 			data: file.src,
 			includePaths: [file.root],
 			indentedSyntax: file.type === 'sass'
 		}, opts));
 
+		file.src = result.css;
 		file.type = 'css';
 	};
 };


### PR DESCRIPTION
##### Summary
- As [documented by node-sass](https://github.com/sass/node-sass#result-object), the result object will contain a `css` property which is the rendered css string. Duo expects the file body on `file.src`.
- This is a change introduced in [node-sass 2.0](https://github.com/sass/node-sass/commit/9026ed1467fea36c2bbf916e946ff18bfee064ab#diff-04c6e90faac2675aa89e2176d2eec7d8), which the dependency is pinned to.
- This caused the failure seen in [node 0.10 Travis tests](https://travis-ci.org/duojs/sass/jobs/51644026), which are now fixed. The other tests have larger issues, highlighted in #7.
